### PR TITLE
#9: Implements mergeSome on a sequence of futures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.9
+
+**New features**
+- Added `mergeSome` to a `SequenceType` of `Future`s to collapse a list of `Future`s into a single one and succeeds even if some of the `Future`s fail (contrast to `merge`)
+
 ## 0.8
 
 **Breaking changes**

--- a/PiedPiper/Future+MergeSome.swift
+++ b/PiedPiper/Future+MergeSome.swift
@@ -1,0 +1,24 @@
+extension SequenceType where Generator.Element: Async {
+  /**
+   Merges this sequence of Futures into a single one containing the list of the results of each Future
+
+   - returns: A Future that will succeed with the list of results of the single Futures contained in this Sequence. The resulting Future will fail or be canceled if one of the elements of this sequence fails or is canceled
+   */
+  public func mergeSome() -> Future<[Generator.Element.Value]> {
+    let result = reduce(Future([]), combine: { accumulator, value in
+      accumulator.flatMap { reduced in
+        value.future.map { mapped in
+          reduced + [mapped]
+        }.recover{ () in reduced }
+      }
+    })
+
+    result.onCancel {
+      self.forEach {
+        $0.future.cancel()
+      }
+    }
+
+    return result
+  }
+}

--- a/PiedPiperSample.xcodeproj/project.pbxproj
+++ b/PiedPiperSample.xcodeproj/project.pbxproj
@@ -70,6 +70,7 @@
 		52BED32F1CE8733C002C045A /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 52BED32E1CE8733C002C045A /* Quick.framework */; };
 		52BED3331CE87396002C045A /* Nimble.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 52BED3311CE87396002C045A /* Nimble.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		52BED3341CE87396002C045A /* Quick.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 52BED3321CE87396002C045A /* Quick.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		9710F1891CFE9C4400713D3B /* Future+MergeSome.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9710F1881CFE9C4400713D3B /* Future+MergeSome.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -167,6 +168,7 @@
 		52BED32E1CE8733C002C045A /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = Carthage/Build/iOS/Quick.framework; sourceTree = "<group>"; };
 		52BED3311CE87396002C045A /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = Carthage/Build/iOS/Nimble.framework; sourceTree = "<group>"; };
 		52BED3321CE87396002C045A /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = Carthage/Build/iOS/Quick.framework; sourceTree = "<group>"; };
+		9710F1881CFE9C4400713D3B /* Future+MergeSome.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Future+MergeSome.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -274,6 +276,7 @@
 				52BED2EA1CE8718D002C045A /* Result+Filter.swift */,
 				52BED2EB1CE8718D002C045A /* Result+flatMap.swift */,
 				52BED2EC1CE8718D002C045A /* Result+Map.swift */,
+				9710F1881CFE9C4400713D3B /* Future+MergeSome.swift */,
 			);
 			path = PiedPiper;
 			sourceTree = "<group>";
@@ -527,6 +530,7 @@
 				52BED2F41CE8718D002C045A /* Future+Reduce.swift in Sources */,
 				52BED2FD1CE8718D002C045A /* Result+Map.swift in Sources */,
 				52BED2F61CE8718D002C045A /* Future+Zip.swift in Sources */,
+				9710F1891CFE9C4400713D3B /* Future+MergeSome.swift in Sources */,
 				52BED2F71CE8718D002C045A /* GCD.swift in Sources */,
 				52BED2ED1CE8718D002C045A /* FunctionComposition.swift in Sources */,
 				52BED2F11CE8718D002C045A /* Future+Map.swift in Sources */,
@@ -848,6 +852,7 @@
 				52B29CFA1CEA236E00B5B277 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		52BED29F1CE870F2002C045A /* Build configuration list for PBXProject "PiedPiperSample" */ = {
 			isa = XCConfigurationList;

--- a/PiedPiperTests/Future+MergeTests.swift
+++ b/PiedPiperTests/Future+MergeTests.swift
@@ -192,5 +192,151 @@ class FutureSequenceMergeTests: QuickSpec {
         expect(successValue).to(equal(expectedResult))
       }
     }
+
+    describe("MergeSome a list of futures") {
+      var promises: [Promise<Int>]!
+      var mergedFuture: Future<[Int]>!
+      var successValue: [Int]?
+      var failureValue: ErrorType?
+      var wasCanceled: Bool!
+      var originalPromisesCanceled: [Bool]!
+
+      let numberOfPromises = 5
+
+      beforeEach {
+        originalPromisesCanceled = (0..<numberOfPromises).map { _ in
+          false
+        }
+        promises = (0..<numberOfPromises).map { idx in
+          Promise().onCancel {
+            originalPromisesCanceled[idx] = true
+          }
+        }
+
+        wasCanceled = false
+        successValue = nil
+        failureValue = nil
+
+        mergedFuture = promises
+          .map { $0.future }
+          .mergeSome()
+
+        mergedFuture.onCompletion { result in
+          switch result {
+          case .Success(let value):
+            successValue = value
+          case .Error(let error):
+            failureValue = error
+          case .Cancelled:
+            wasCanceled = true
+          }
+        }
+      }
+
+      context("when one of the original futures fails") {
+        let expectedError = TestError.AnotherError
+
+        beforeEach {
+          promises.first?.succeed(10)
+          promises[1].fail(expectedError)
+          promises[2..<numberOfPromises].forEach{ promise in
+            promise.succeed(10)
+          }
+        }
+
+        it("should not fail the merged future") {
+          expect(failureValue).to(beNil())
+        }
+
+        it("should not cancel the merged future") {
+          expect(wasCanceled).to(beFalse())
+        }
+
+        it("should succeed the merged future") {
+          expect(successValue).notTo(beNil())
+        }
+
+        it("should succeed only the non-failing futures") {
+          expect(successValue!.count).to(equal(numberOfPromises-1))
+        }
+      }
+
+      context("when one of the original futures is canceled") {
+        beforeEach {
+          promises.first?.succeed(10)
+          promises[1].cancel()
+        }
+
+        it("should not fail the merged future") {
+          expect(failureValue).to(beNil())
+        }
+
+        it("should cancel the merged future") {
+          expect(wasCanceled).to(beTrue())
+        }
+
+        it("should not succeed the merged future") {
+          expect(successValue).to(beNil())
+        }
+      }
+
+      context("when all the original futures succeed") {
+        var expectedResult: [Int]!
+
+        context("when they succeed in the same order") {
+          beforeEach {
+            expectedResult = promises.enumerate().map { $0.index }
+            promises.enumerate().forEach { (iteration, promise) in
+              promise.succeed(iteration)
+            }
+          }
+
+          it("should not fail the merged future") {
+            expect(failureValue).to(beNil())
+          }
+
+          it("should not cancel the merged future") {
+            expect(wasCanceled).to(beFalse())
+          }
+
+          it("should succeed the merged future") {
+            expect(successValue).notTo(beNil())
+          }
+
+          it("should succeed with the right value") {
+            expect(successValue).to(equal(expectedResult))
+          }
+        }
+      }
+
+      context("when canceling the merged future") {
+        context("when no promise was done") {
+          beforeEach {
+            mergedFuture.cancel()
+          }
+
+          it("should cancel all the running promises") {
+            expect(originalPromisesCanceled).to(allPass({ $0 == true}))
+          }
+        }
+
+        context("when some promise was done") {
+          let nonRunningPromiseIndex = 1
+
+          beforeEach {
+            promises[nonRunningPromiseIndex].succeed(10)
+            mergedFuture.cancel()
+          }
+
+          it("should cancel only the non running promises") {
+            expect(originalPromisesCanceled.filter({ $0 == true }).count).to(equal(promises.count - 1))
+          }
+
+          it("should not cancel the non running promises") {
+            expect(originalPromisesCanceled[nonRunningPromiseIndex]).to(beFalse())
+          }
+        }
+      }
+    }
   }
 }

--- a/README.md
+++ b/README.md
@@ -306,11 +306,26 @@ let sumOfServerResults = serverRequests.reduce(0, combine: +).onSuccess {
 // Let's assume this value contains a list of server requests where each request obtains the number of items in a given category
 let serverRequests: [Future<Int>] = doFoo()
 
-// With this `merge` call we collapse the requests into one containing the result of all of them, if they all succeeded
+// With this `merge` call we collapse the requests into one containing the result of all of them, if they all succeeded, or none if one fails
 let allServerResults = serverRequests.merge().onSuccess { results in
   // We get here only if all futures succeed
   // `results` is an [Int]
 }
+```
+
+#### MergeSome
+
+```swift
+// Let's assume this value contains a list of server requests where each request obtains the number of items in a given category
+let serverRequests: [Future<Int>] = doFoo()
+
+// With this `merge` call we collapse the requests into one containing the result of just the ones that succeed
+let allServerResults = serverRequests.mergeSome().onSuccess { results in
+  // We get here and results.count == the number of succeeded requests
+  // `results` is an [Int]
+}
+
+// Note: `merge` succeeds only when _all_ requests succeed, while `mergeSome` always succeeds and filters out the failed requests from the results
 ```
 
 #### Traverse


### PR DESCRIPTION
See #9 

This seems like a simpler implementation than what you had done for `batchGetSome` in Carlos and it seems to work (passes tests similar to `merge` tests).

The implementation I went with is essentially `reduce` except with an extra `recover` to make sure nothing will fail.

We could even refactor this into `reduceSome` (with some handler for the error case) and then `mergeSome` is a specialization of that -- however, I can't think of a use for such a method so I just inlined what would be `reduceSome` inside of `mergeSome`.

I like what you said re: `mergeAll` and `mergeSome` -- I didn't change `merge` to `mergeAll` since I'm sure you'll want to deprecate that, but called this method `mergeSome`.
